### PR TITLE
InputDispatcher: allow to intercept a specific event key

### DIFF
--- a/services/inputflinger/dispatcher/Android.bp
+++ b/services/inputflinger/dispatcher/Android.bp
@@ -58,6 +58,7 @@ cc_library_static {
     defaults: [
         "inputflinger_defaults",
         "libinputdispatcher_defaults",
+        "inputdispatcher_skip_event_key_defaults",
     ],
     shared_libs: [
         // This should consist only of dependencies from inputflinger. Other dependencies should be

--- a/services/inputflinger/dispatcher/InputDispatcher.cpp
+++ b/services/inputflinger/dispatcher/InputDispatcher.cpp
@@ -1161,6 +1161,14 @@ bool InputDispatcher::dispatchKeyLocked(nsecs_t currentTime, KeyEntry* entry,
     // Give the policy a chance to intercept the key.
     if (entry->interceptKeyResult == KeyEntry::INTERCEPT_KEY_RESULT_UNKNOWN) {
         if (entry->policyFlags & POLICY_FLAG_PASS_TO_USER) {
+            if (INPUTDISPATCHER_SKIP_EVENT_KEY != 0) {
+                if(entry->keyCode == 0 && entry->scanCode == INPUTDISPATCHER_SKIP_EVENT_KEY) {
+                    entry->interceptKeyResult = KeyEntry::INTERCEPT_KEY_RESULT_SKIP;
+                    *dropReason = DropReason::POLICY;
+                    ALOGI("Intercepted the key %i", INPUTDISPATCHER_SKIP_EVENT_KEY);
+                    return true;
+                }
+            }
             std::unique_ptr<CommandEntry> commandEntry = std::make_unique<CommandEntry>(
                     &InputDispatcher::doInterceptKeyBeforeDispatchingLockedInterruptible);
             sp<InputWindowHandle> focusedWindowHandle =


### PR DESCRIPTION
[arrow-11.0 edits]: make the key to intercept configurable using TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY

Fixes a lag in the UI when scrolling while holding the fingerprint sensor

Test : Open a webpage and scroll while having a finger on the fingerprint sensor

Change-Id: Ic3bccc351875283d4bb7a5613c60389d966137d3
Signed-off-by: daniml3 danimoral1001@gmail.com